### PR TITLE
Update regexes so that it doesn't strip first \n

### DIFF
--- a/lib/nixt/formatter.js
+++ b/lib/nixt/formatter.js
@@ -53,10 +53,10 @@ Formatter.prototype.load = function(stdout, stderr) {
  */
 
 Formatter.prototype.strip = function(str) {
-  str = str.replace(/\r?\n|\r$/, '');
+  str = str.replace(/\r?\n$/, '');
 
   if (this.newlines === false) {
-    str = str.replace(/\r?\n|\r/g, '');
+    str = str.replace(/\r?\n/g, '');
   }
 
   if (this.colors === false) {

--- a/test/fixtures/newlines-crlf.js
+++ b/test/fixtures/newlines-crlf.js
@@ -1,0 +1,2 @@
+console.log(['Hello', 'from', 'newlines-crlf.js'].join(' \r\n'));
+console.error(['Error', 'from', 'newlines-crlf.js'].join(' \r\n'));

--- a/test/newlines.test.js
+++ b/test/newlines.test.js
@@ -2,12 +2,39 @@ var nixt = require('..');
 var join = require('path').join;
 
 describe('nixt', function() {
-  it('can strip new lines from stdout and stderr', function(done) {
+  it('can strip \\n from stdout and stderr', function(done) {
     nixt({ newlines: false })
     .cwd(join(__dirname, 'fixtures'))
     .run('node newlines.js')
     .stdout('Hello from newlines.js')
     .stderr('Error from newlines.js')
+    .end(done);
+  });
+  
+  it('can leave \\n in stdout and stderr', function(done) {
+    nixt({ newlines: true })
+    .cwd(join(__dirname, 'fixtures'))
+    .run('node newlines.js')
+    .stdout('Hello \nfrom \nnewlines.js')
+    .stderr('Error \nfrom \nnewlines.js')
+    .end(done);
+  });
+  
+  it('can strip \\r\\n from stdout and stderr', function(done) {
+    nixt({ newlines: false })
+    .cwd(join(__dirname, 'fixtures'))
+    .run('node newlines-crlf.js')
+    .stdout('Hello from newlines-crlf.js')
+    .stderr('Error from newlines-crlf.js')
+    .end(done);
+  });
+  
+  it('can leave \\r\\n in stdout and stderr', function(done) {
+    nixt({ newlines: true })
+    .cwd(join(__dirname, 'fixtures'))
+    .run('node newlines-crlf.js')
+    .stdout('Hello \r\nfrom \r\nnewlines-crlf.js')
+    .stderr('Error \r\nfrom \r\nnewlines-crlf.js')
     .end(done);
   });
 });


### PR DESCRIPTION
I started trying to use nixt on a project and while I love the API, it was weirdly stripping the very first `\n` in my stdout/stderr strings. I did some digging around and I'm pretty sure I tracked down why.

It has to do with operator precedence inside regexes, [here's an example](http://regexpal.com/?flags=g&regex=a%3Fb|b%24&input=fooga%20ab%20wooga%20booga%20b) of what is happening. You can fix it in a couple of ways, either by using a [non-capturing group](http://regexpal.com/?flags=g&regex=%28%3F%3Aa%3Fb|b%29%24&input=fooga%20ab%20wooga%20booga%20b) or just by dropping the `OR` entirely since I don't think a `\r` by itself should be appearing anywhere. I chose to drop the `OR` entirely, but it'd be trivial to add back in & use a group instead.

For my own sanity I fleshed out the newline tests a bit by adding `\r\n` tests & a fixture as well, just to make sure I wasn't regressing anything.
