### PR TITLE
Extra assertion properties for pretty diffs

### DIFF
--- a/lib/nixt/expectations.js
+++ b/lib/nixt/expectations.js
@@ -21,7 +21,8 @@ var AssertionError = require('assertion-error');
 exports.code = function(code) {
   return function(result) {
     if (code !== result.code) {
-      return error(result, 'Expected exit code: "' + code + '", actual: "' + result.code + '"');
+      var message = 'Expected exit code: "' + code + '", actual: "' + result.code + '"';
+      return error(result, message, code, result.code);
     }
   };
 };


### PR DESCRIPTION
I dig the simple nixt assertion API but reading the results is pretty tough for me. Especially in that red color. So I did some reading on what mocha expects from assertions so that it can draw its nice assertion diffs. Turns out to be pretty straightforward, two extra properties on the assertion itself: `expected` and `actual`.

I plumbed the changes through all the expectations that deal with string content, I don't love how this complicated the API though. I did make sure the extra params are optional but that's just a band-aid. If you'd like me to rework the implementation at all I'd be happy to do so. This doesn't effect any of the existing tests since I left the message bodies alone & just added extra params to let mocha do some prettying up.

**Original**
![master](https://f.cloud.github.com/assets/49545/1908174/24cb03e6-7cec-11e3-8cde-0abfb3c20b24.png)

*_Pull Request *_
![pull-request](https://f.cloud.github.com/assets/49545/1908175/32bd9266-7cec-11e3-9b13-e8cfd793457c.png)
