### PR TITLE
Test against nonzero exit codes

### DIFF
--- a/lib/nixt/result.js
+++ b/lib/nixt/result.js
@@ -5,9 +5,10 @@
  * @constructor
  */
 
-function Result(cmd, options) {
+function Result(cmd, code, options) {
   options = options || {};
   this.options = options;
+  this.code = code;
   this.cmd = cmd;
 }
 
@@ -22,7 +23,7 @@ function Result(cmd, options) {
 
 Result.prototype.parse = function(stdout, stderr, err) {
   this.err = err;
-  this.code = err ? err.code : 0;
+  this.code = err ? err.code : this.code;
   this.killed = err && err.killed;
   this.stdout = this.strip(stdout);
   this.stderr = this.strip(stderr);

--- a/lib/nixt/runner.js
+++ b/lib/nixt/runner.js
@@ -413,7 +413,7 @@ Runner.prototype.execFn = function(cmd) {
 
     child.on('exit', function(code) {
       var error = null;
-      var result = new Result(cmd, self.options).parse(stdout, stderr, err);
+      var result = new Result(cmd, code, self.options).parse(stdout, stderr, err);
 
       for (var i = 0, len = self.expectations.length; i < len; i++) {
         error = self.expectations[i](result);

--- a/test/code.test.js
+++ b/test/code.test.js
@@ -6,12 +6,22 @@ describe('nixt#code', function() {
     .end(done);
   });
 
-  it('returns na error when the exit code does not match the expected one', function(done) {
+  it('returns an error when the exit code does not match the expected one', function(done) {
     nfixt()
     .run('node code-0.js')
     .code(1)
     .end(function(err) {
       err.message.should.eq('`node code-0.js`: Expected exit code: "1", actual: "0"');
+      done();
+    });
+  });
+
+  it('returns an error when the nonzero exit code does not match the expected one', function(done) {
+    nfixt()
+    .run('node code-1.js')
+    .code(0)
+    .end(function(err) {
+      err.message.should.eq('`node code-1.js`: Expected exit code: "0", actual: "1"');
       done();
     });
   });

--- a/test/fixtures/code-1.js
+++ b/test/fixtures/code-1.js
@@ -1,0 +1,1 @@
+process.exit(1);


### PR DESCRIPTION
Previously, the exit code defaulted to zero if the command completed without timing out. This made it impossible to assert an expectation for a nonzero exit code. This fixes that.
