### PR TITLE
Add #stdin method

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,9 +250,9 @@ Set the contents of stdin.
 
 ```js
 nixt()
-.stdin('foo')
-.run('node -e "process.stdin.pipe(process.stdout)"')
-.stdout('foo')
+.stdin('foobar')
+.run('rev')
+.stdout('raboof')
 .end(fn);
 ```
 

--- a/README.md
+++ b/README.md
@@ -244,6 +244,18 @@ nixt()
 .run('node --version', fn)
 ```
 
+### #stdin
+
+Set the contents of stdin.
+
+```js
+nixt()
+.stdin('foo')
+.run('node -e "process.stdin.pipe(process.stdout)"')
+.stdout('foo')
+.end(fn);
+```
+
 ### #env
 
 Set environment variables.

--- a/lib/nixt/runner.js
+++ b/lib/nixt/runner.js
@@ -77,6 +77,7 @@ function Runner(options) {
   this.prompts = [];
   this.responses = [];
   this.baseCmd = '';
+  this.standardInput = null;
 }
 
 /**
@@ -134,6 +135,19 @@ Runner.prototype.cwd = function(path) {
 
 Runner.prototype.base = function(cmd) {
   this.baseCmd = cmd;
+  return this;
+};
+
+/**
+ * Set data to pass to stdin.
+ *
+ * @param {String} data
+ * @returns {Runner} for chaining
+ * @api public
+ */
+
+Runner.prototype.stdin = function(data) {
+  this.standardInput = data || '';
   return this;
 };
 
@@ -398,6 +412,10 @@ Runner.prototype.execFn = function(cmd) {
     var stdout = '';
     var stderr = '';
     var err;
+
+    if (self.standardInput != null) {
+      child.stdin.end(self.standardInput);
+    }
 
     if (self.world.timeout) {
       setTimeout(function() {

--- a/test/fixtures/rev.js
+++ b/test/fixtures/rev.js
@@ -1,0 +1,17 @@
+var data = '';
+
+process.stdin.on('data', function (chunk) {
+  var lines = (data + chunk).split('\n');
+  data = lines.pop();
+  lines.forEach(printReversed);
+});
+
+process.stdin.on('end', function () {
+  if (data) {
+    printReversed(data);
+  }
+});
+
+function printReversed (line) {
+  console.log(line.split('').reverse().join(''));
+}

--- a/test/stdin.test.js
+++ b/test/stdin.test.js
@@ -1,0 +1,24 @@
+describe('nixt#stdin', function() {
+  it('no effect if stdin is not used', function(done) {
+    nfixt()
+    .run('node hello.js')
+    .stdout('Hello')
+    .end(done);
+  });
+
+  it('passes given string on stdin', function(done) {
+    nfixt()
+    .stdin('foo\nbar')
+    .run('node rev.js')
+    .stdout('oof\nrab')
+    .end(done);
+  });
+
+  it('does end the input stream', function(done) {
+    nfixt()
+    .stdin('')
+    .run('node rev.js')
+    .stdout('')
+    .end(done);
+  });
+});


### PR DESCRIPTION
This patch adds `Runner.prototype.stdin` method for setting the contents of standard input stream. Useful when a program under test reads data from stdin.

Usage:

```js
nixt()
  .stdin('foo\nbar')
  .run('node rev.js')
  .stdout('oof\nrab')
  .end(done);
```

Would close #12.