### PR TITLE
Wait for standard IO streams to close

### DIFF
--- a/lib/nixt/runner.js
+++ b/lib/nixt/runner.js
@@ -411,7 +411,7 @@ Runner.prototype.execFn = function(cmd) {
     child.stdout.on('data', function(data) { stdout += data; });
     child.stderr.on('data', function(data) { stderr += data; });
 
-    child.on('exit', function(code) {
+    child.on('close', function(code) {
       var error = null;
       var result = new Result(cmd, code, self.options).parse(stdout, stderr, err);
 


### PR DESCRIPTION
Currently test results are evaluated [in the listener for `exit` event](https://github.com/vesln/nixt/blob/4d178e69c02e20a79c23479dae7100b90bb278d5/lib/nixt/runner.js#L414) of the child process. However, [exit] event is not guaranteed to be emitted *after* standard output streams are closed, as demostrated by the program below:

```js
var spawn = require('child_process').spawn;

var cp = spawn('echo', ['foo']);
cp.stdout.on('data', console.log);
cp.on('exit', () => console.log('exit'));
```

```
$ node --version
v5.0.0
$ node example.js
exit
<Buffer 66 6f 6f 0a>
```

See also [this warning][exit] from Node.js docs:

> Note that when the 'exit' event is triggered, child process stdio streams might still be open.

I can't come up with a failing test for this, but here's a failing example on the command line:

```js
$ node -e 'require("./")().run("echo foo").stdout("foo").end(err => { if (err) console.log(err.toString()) })'
AssertionError: `echo foo`: Expected stdout to match "foo". Actual: ""
```

This patch listens for [close] event instead:

> The 'close' event is emitted when the stdio streams of a child process have been closed.

[exit]: https://nodejs.org/api/child_process.html#child_process_event_exit
[close]: https://nodejs.org/api/child_process.html#child_process_event_close